### PR TITLE
fix: semantic handling of beta releases

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ name: "Addon Factory Splunk Package Version"
 description: "Produce a version for Splunk packages compatible with splunkbase"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/splunk/addonfactory-get-splunk-package-version-action:v1.1.6"
+  image: "Dockerfile"
 inputs:
   SemVer:
     description: Ouput of SEMVER step

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ then
     VERSION=$INPUT_SEMVER
 elif [[ $INPUT_SEMVER =~ $BETA_REGEX ]];
 then
-    VERSION=$(echo $INPUT_SEMVER | awk '{gsub("-beta\.", "B");print}')
+    VERSION=$(echo $INPUT_SEMVER | awk '{gsub("-beta\.", "-B");print}')
 else
     if [[ $GITHUB_EVENT_NAME != 'pull_request' ]];
     then


### PR DESCRIPTION
Due to incorrect handling of version for beta release, splunk appinspect failures are observed.
Tested without fix here: https://github.com/splunk/test-addonfactory-repo/actions/runs/5738914451/job/15553584735
Tested with fix here: https://github.com/splunk/test-addonfactory-repo/actions/runs/5738313258/job/15553318904